### PR TITLE
Remove unused log format arg

### DIFF
--- a/pyathenajdbc/cursor.py
+++ b/pyathenajdbc/cursor.py
@@ -109,7 +109,7 @@ class Cursor(object):
                 self._meta_data = None
                 self._update_count = self._statement.getUpdatecount()
         except Exception as e:
-            _logger.exception('Failed to execute query.', e)
+            _logger.exception('Failed to execute query.')
             reraise_dbapi_error()
 
     def executemany(self, operation, seq_of_parameters):


### PR DESCRIPTION
This resolves previous TypeError: not all arguments converted during
string formatting messages thrown by logging