### PR TITLE
Fixed not finding JDBC driver class when creating multiple connections

### DIFF
--- a/pyathenajdbc/connection.py
+++ b/pyathenajdbc/connection.py
@@ -16,6 +16,7 @@ from pyathenajdbc.error import ProgrammingError, NotSupportedError
 from pyathenajdbc.formatter import ParameterFormatter
 from pyathenajdbc.util import synchronized
 
+
 _logger = logging.getLogger(__name__)
 
 

--- a/pyathenajdbc/connection.py
+++ b/pyathenajdbc/connection.py
@@ -14,7 +14,7 @@ from pyathenajdbc.converter import JDBCTypeConverter
 from pyathenajdbc.cursor import Cursor
 from pyathenajdbc.error import ProgrammingError, NotSupportedError
 from pyathenajdbc.formatter import ParameterFormatter
-
+from pyathenajdbc.util import synchronized
 
 _logger = logging.getLogger(__name__)
 
@@ -72,6 +72,7 @@ class Connection(object):
         self._formatter = formatter if formatter else ParameterFormatter()
 
     @classmethod
+    @synchronized
     def _start_jvm(cls, jvm_path, jvm_options, driver_path):
         if jvm_path is None:
             jvm_path = jpype.get_default_jvm_path()

--- a/pyathenajdbc/connection.py
+++ b/pyathenajdbc/connection.py
@@ -76,7 +76,7 @@ class Connection(object):
         if jvm_path is None:
             jvm_path = jpype.get_default_jvm_path()
         if driver_path is None:
-            driver_path = os.path.join(os.path.dirname(__file__), ATHENA_JAR)
+            driver_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ATHENA_JAR)
         if not jpype.isJVMStarted():
             _logger.debug('JVM path: %s', jvm_path)
             args = ['-server', '-Djava.class.path={0}'.format(driver_path)]
@@ -84,8 +84,15 @@ class Connection(object):
                 args.extend(jvm_options)
             _logger.debug('JVM args: %s', args)
             jpype.startJVM(jvm_path, *args)
+            cls.class_loader = jpype.java.lang.Thread.currentThread().getContextClassLoader()
         if not jpype.isThreadAttachedToJVM():
             jpype.attachThreadToJVM()
+            if not cls.class_loader:
+                cls.class_loader = jpype.java.lang.Thread.currentThread().getContextClassLoader()
+            class_loader = jpype.java.net.URLClassLoader.newInstance(
+                [jpype.java.net.URL('jar:file:{0}!/'.format(driver_path))],
+                cls.class_loader)
+            jpype.java.lang.Thread.currentThread().setContextClassLoader(class_loader)
 
     def _build_driver_args(self, **kwargs):
         props = jpype.java.util.Properties()

--- a/pyathenajdbc/util.py
+++ b/pyathenajdbc/util.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import functools
 import sys
+import threading
 
 from future.utils import reraise
 
@@ -33,3 +35,16 @@ def reraise_dbapi_error():
     else:
         tp = exc_info[0]
     reraise(tp, value, exc_info[2])
+
+
+def synchronized(wrapped):
+    """The missing @synchronized decorator
+
+    https://git.io/vydTA"""
+    _lock = threading.RLock()
+
+    @functools.wraps(wrapped)
+    def _wrapper(*args, **kwargs):
+        with _lock:
+            return wrapped(*args, **kwargs)
+    return _wrapper

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         'Pandas': ['pandas>=0.19.0']
     },
     tests_require=[
+        'futures',
         'pytest',
         'pytest-cov',
         'pytest-flake8',

--- a/tests/test_pyathenajdbc.py
+++ b/tests/test_pyathenajdbc.py
@@ -5,7 +5,6 @@ import contextlib
 import os
 import random
 import string
-import time
 import unittest
 from datetime import datetime, date
 
@@ -280,7 +279,6 @@ class TestPyAthenaJDBC(unittest.TestCase):
 
     def test_multiple_connection(self):
         def execute_other_thread():
-            time.sleep(random.random())
             with contextlib.closing(connect(schema_name=_SCHEMA)) as conn:
                 with conn.cursor() as cursor:
                     cursor.execute('SELECT * FROM one_row')

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26,py27,py34,py35
 
 [testenv]
 deps =
+    futures
     pytest
     pytest-cov
     pytest-flake8
@@ -16,6 +17,7 @@ passenv =
 
 [testenv:py26]
 deps =
+    futures
     pytest
     pytest-cov
     pytest-catchlog


### PR DESCRIPTION
Sometimes JVM crashes with multithreaded test case. The cause is that JPype does not support multithreading.
originell/jpype#211
