### PR TITLE
Adding a dict default formatter, returning an empty string

### DIFF
--- a/pyathenajdbc/formatter.py
+++ b/pyathenajdbc/formatter.py
@@ -131,4 +131,5 @@ _DEFAULT_FORMATTERS = {
     list: _format_seq,
     set: _format_seq,
     tuple: _format_seq,
+    dict: lambda formatter, escaper, val: '',
 }


### PR DESCRIPTION
If this is the correct solution remains to be seen, but it seems to work wonders
with the the sqlalchemy athena driver (For now, available here: https://github.com/dwa/PyHive/tree/dwa-tobii-sqlalchemy-athena)

