### PR TITLE
Issue 41: Replace InstanceProfileCredentialsProvider with DefaultAWSCredentialsProviderChain

### DIFF
--- a/pyathenajdbc/connection.py
+++ b/pyathenajdbc/connection.py
@@ -108,7 +108,7 @@ class Connection(object):
         elif self.token:
             props.setProperty('aws_credentials_provider_class',
                               'com.amazonaws.athena.jdbc.shaded.' +
-                              'com.amazonaws.auth.InstanceProfileCredentialsProvider')
+                              'com.amazonaws.auth.DefaultAWSCredentialsProviderChain')
         else:
             props.setProperty('user', self.access_key)
             props.setProperty('password', self.secret_key)

--- a/scripts/test_data/delete_test_data.sh
+++ b/scripts/test_data/delete_test_data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+[[ "${AWS_ATHENA_S3_STAGING_DIR:(-1)}" == '/' ]] || { echo "Please add trailing '/' to your AWS_ATHENA_S3_STAGING_DIR."; exit 1; }
+
 aws s3 rm ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/one_row/one_row.tsv
 aws s3 rm ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/one_row_complex/one_row_complex.tsv
 aws s3 rm ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/many_rows/many_rows.tsv

--- a/scripts/test_data/upload_test_data.sh
+++ b/scripts/test_data/upload_test_data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+[[ "${AWS_ATHENA_S3_STAGING_DIR:(-1)}" == '/' ]] || { echo "Please add trailing '/' to your AWS_ATHENA_S3_STAGING_DIR."; exit 1; }
+
 aws s3 cp $(dirname $0)/one_row.tsv ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/one_row/one_row.tsv
 aws s3 cp $(dirname $0)/one_row_complex.tsv ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/one_row_complex/one_row_complex.tsv
 aws s3 cp $(dirname $0)/many_rows.tsv ${AWS_ATHENA_S3_STAGING_DIR}test_pyathena_jdbc/many_rows/many_rows.tsv

--- a/tests/test_pyathenajdbc.py
+++ b/tests/test_pyathenajdbc.py
@@ -224,7 +224,7 @@ class TestPyAthenaJDBC(unittest.TestCase):
         self.assertIsNone(cursor.output_location)
         cursor.execute('SELECT * from one_row')
         self.assertEqual(cursor.output_location,
-                         '{0}/{1}.csv'.format(ENV.s3_staging_dir, cursor.query_id))
+                         '{0}{1}.csv'.format(ENV.s3_staging_dir, cursor.query_id))
 
     @with_cursor
     def test_complex(self, cursor):

--- a/tests/test_pyathenajdbc.py
+++ b/tests/test_pyathenajdbc.py
@@ -224,7 +224,7 @@ class TestPyAthenaJDBC(unittest.TestCase):
         self.assertIsNone(cursor.output_location)
         cursor.execute('SELECT * from one_row')
         self.assertEqual(cursor.output_location,
-                         '{0}{1}.csv'.format(ENV.s3_staging_dir, cursor.query_id))
+                         '{0}/{1}.csv'.format(ENV.s3_staging_dir, cursor.query_id))
 
     @with_cursor
     def test_complex(self, cursor):


### PR DESCRIPTION
The DefaultAWSCredentialsProviderChain enables PyAthenaJDBC to support ECS, Lambda, and CLI in addition to EC2 Instances.