### PR TITLE
Support custom RoleArn in Athena connection URI

### DIFF
--- a/pyathenajdbc/__init__.py
+++ b/pyathenajdbc/__init__.py
@@ -58,9 +58,11 @@ Timestamp = datetime.datetime
 def connect(s3_staging_dir=None, access_key=None, secret_key=None,
             region_name=None, schema_name='default', profile_name=None, credential_file=None,
             jvm_path=None, jvm_options=None, converter=None, formatter=None,
+            role_arn=None, role_session_name='PyAthenaJDBCDefaultSession',
             driver_path=None, **kwargs):
     from pyathenajdbc.connection import Connection
     return Connection(s3_staging_dir, access_key, secret_key,
                       region_name, schema_name, profile_name, credential_file,
                       jvm_path, jvm_options, converter, formatter,
+                      role_arn, role_session_name,
                       driver_path, **kwargs)


### PR DESCRIPTION
This patch allows to provide a custom RoleArn in Athena Connection URI. This is useful when we need to switch to another role from within Ec2 instance profile.

Example Connection Uri:

awsathena+jdbc://athena.ap-southeast-1.amazonaws.com:443/testing?s3_staging_dir=s3://athena-query-results-testing&role_arn=arn:aws:iam::024150960000:role/AthenaPowerUsers