### PR TITLE
Fix broken test for desc query

### DIFF
--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -374,8 +374,8 @@ class TestCursor(unittest.TestCase):
         cursor.execute('DESC one_row')
         self.assertEqual(cursor.description, [
             ('col_name', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
-            ('data_type', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
-            ('comment', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
+            ('data_type', 'LONGNVARCHAR', 0, None, 0, 0, 2),
+            ('comment', 'LONGNVARCHAR', 0, None, 0, 0, 2),
         ])
         self.assertEqual(cursor.fetchall(), [
             ('number_of_rows      \tint                 \t                    ',)


### PR DESCRIPTION
```
=================================== FAILURES ===================================
__________________________ TestCursor.test_desc_query __________________________
self = <tests.test_cursor.TestCursor testMethod=test_desc_query>
cursor = <pyathenajdbc.cursor.Cursor object at 0x7f192b0b5390>
    @with_cursor
    def test_desc_query(self, cursor):
        cursor.execute('DESC one_row')
        self.assertEqual(cursor.description, [
            ('col_name', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
            ('data_type', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
>           ('comment', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
        ])
E       AssertionError: Lists differ: [('co[87 chars]AR', 0, None, 0, 0, 2), ('comment', 'LONGNVARC[19 chars], 2)] != [('co[87 chars]AR', 1073741824, None, 1073741824, 0, 2), ('co[55 chars], 2)]
E       
E       First differing element 1:
E       ('data_type', 'LONGNVARCHAR', 0, None, 0, 0, 2)
E       ('data_type', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2)
E       
E         [('col_name', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
E       -  ('data_type', 'LONGNVARCHAR', 0, None, 0, 0, 2),
E       ?                                           ---
E       
E       +  ('data_type', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2),
E       ?                                + ++++++++        ++++++++++++
E       
E       -  ('comment', 'LONGNVARCHAR', 0, None, 0, 0, 2)]
E       ?                                         ---
E       
E       +  ('comment', 'LONGNVARCHAR', 1073741824, None, 1073741824, 0, 2)]
E       ?                              + ++++++++        ++++++++++++
tests/test_cursor.py:378: AssertionError
```