### PR TITLE
Fix double escaping of percent character in SQLAlchemy

### DIFF
--- a/tests/test_sqlalchemy_athena.py
+++ b/tests/test_sqlalchemy_athena.py
@@ -171,3 +171,34 @@ class TestSQLAlchemyAthena(unittest.TestCase):
         self.assertIn('"current_timestamp"', query)
         self.assertNotIn('`select`', query)
         self.assertNotIn('`current_timestamp`', query)
+
+    @with_engine
+    def test_contain_percents_character_query(self, engine, connection):
+        query = sqlalchemy.sql.text("""
+        SELECT date_parse('20191030', '%Y%m%d')
+        """)
+        result = engine.execute(query)
+        self.assertEqual(result.fetchall(), [(datetime(2019, 10, 30), )])
+
+    @with_engine
+    def test_query_with_parameter(self, engine, connection):
+        query = sqlalchemy.sql.text("""
+        SELECT :word
+        """)
+        result = engine.execute(query, word='cat')
+        self.assertEqual(result.fetchall(), [('cat', )])
+
+    @with_engine
+    def test_contain_percents_character_query_with_parameter(self, engine, connection):
+        query = sqlalchemy.sql.text("""
+        SELECT date_parse('20191030', '%Y%m%d'), :word
+        """)
+        result = engine.execute(query, word='cat')
+        self.assertEqual(result.fetchall(), [(datetime(2019, 10, 30), 'cat')])
+
+        query = sqlalchemy.sql.text("""
+        SELECT col_string FROM one_row_complex
+        WHERE col_string LIKE 'a%' OR col_string LIKE :param
+        """)
+        result = engine.execute(query, param='b%')
+        self.assertEqual(result.fetchall(), [('a string', )])


### PR DESCRIPTION
Related:
laughingman7743/PyAthena/issues/56
laughingman7743/PyAthena/pull/57