### PR TITLE
Restrict the allowable version of SQLAlchemy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ Installation
 
 Extra packages:
 
-+---------------+------------------------------------------+----------+
-| Package       | Install command                          | Version  |
-+===============+==========================================+==========+
-| Pandas        | ``pip install PyAthenaJDBC[Pandas]``     | >=0.19.0 |
-+---------------+------------------------------------------+----------+
-| SQLAlchemy    | ``pip install PyAthenaJDBC[SQLAlchemy]`` | >=1.0.0  |
-+---------------+------------------------------------------+----------+
++---------------+------------------------------------------+-----------------+
+| Package       | Install command                          | Version         |
++===============+==========================================+=================+
+| Pandas        | ``pip install PyAthenaJDBC[Pandas]``     | >=0.19.0        |
++---------------+------------------------------------------+-----------------+
+| SQLAlchemy    | ``pip install PyAthenaJDBC[SQLAlchemy]`` | >=1.0.0, <1.3.0 |
++---------------+------------------------------------------+-----------------+
 
 Usage
 -----
@@ -203,7 +203,7 @@ SQLAlchemy
 ~~~~~~~~~~
 
 Install SQLAlchemy with ``pip install SQLAlchemy>=1.0.0`` or ``pip install PyAthenaJDBC[SQLAlchemy]``.
-Supported SQLAlchemy is 1.0.0 or higher.
+Supported SQLAlchemy is 1.0.0 or higher and less than 1.3.0.
 
 .. code:: python
 

--- a/setup.py
+++ b/setup.py
@@ -120,11 +120,11 @@ setup(
     ],
     extras_require={
         'Pandas': ['pandas>=0.19.0'],
-        'SQLAlchemy': ['SQLAlchemy>=1.0.0'],
+        'SQLAlchemy': ['SQLAlchemy>=1.0.0, <1.3.0'],
     },
     tests_require=[
         'futures',
-        'SQLAlchemy>=1.0.0',
+        'SQLAlchemy>=1.0.0, <1.3.0',
         'pytest>=3.5',
         'pytest-cov',
         'pytest-flake8>=1.0.1',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py34,py35,py36
 [testenv]
 deps =
     futures
-    SQLAlchemy>=1.0.0
+    SQLAlchemy>=1.0.0, <1.3.0
     pytest>=3.5
     pytest-cov
     pytest-flake8>=1.0.1


### PR DESCRIPTION
```
=================================== FAILURES ===================================
___________ TestSQLAlchemyAthena.test_reflect_table_include_columns ____________
self = <tests.test_sqlalchemy_athena.TestSQLAlchemyAthena testMethod=test_reflect_table_include_columns>
engine = Engine(awsathena+jdbc://athena.[secure].amazonaws.com:443/test_pyathena_jdbc_zizgrcxefj?s3_staging_dir=[secure])
connection = <sqlalchemy.engine.base.Connection object at 0x7f16c4643b38>
    @with_engine
    def test_reflect_table_include_columns(self, engine, connection):
        one_row_complex = Table('one_row_complex', MetaData(bind=engine))
        engine.dialect.reflecttable(
>           connection, one_row_complex, include_columns=['col_int'], exclude_columns=[])
E       TypeError: reflecttable() missing 1 required positional argument: 'resolve_fks'
tests/test_sqlalchemy_athena.py:76: TypeError
```