### PR TITLE
Locking JPype1 dependency to 0.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     ],
     install_requires=[
         'future',
-        'jpype1>=0.6.0',
+        'jpype1==0.6.0',
         'botocore>=1.0.0',
     ],
     extras_require={


### PR DESCRIPTION
- Downgrade JPype1 to 0.6.3. JPype1 released 0.7.0 recently, which is not compatible with old interfaces.